### PR TITLE
Plone 3 queued mail

### DIFF
--- a/Products/EasyNewsletter/configure.zcml
+++ b/Products/EasyNewsletter/configure.zcml
@@ -25,4 +25,41 @@
   <!-- File System Directory Views registration -->
   <cmf:registerDirectory name="EasyNewsletter" directory="skins/EasyNewsletter" />
 
+  <configure
+    zcml:condition="not-have plone-4"
+    xmlns:mail="http://namespaces.zope.org/mail">
+    <include package="zope.sendmail" file="meta.zcml" />
+    <include package="zope.sendmail"/>
+
+    <!-- 
+      THIS IS ALREADY REGISTERED BY zope.sendmail
+      <mail:smtpMailer name="smtp" hostname="localhost" port="25" />
+    -->
+    <!-- 
+      YOU CAN REGISTER YOURS LIKE THIS
+
+    <mail:smtpMailer
+      name="mycompany_smtp"
+      hostname="mail.mycompany.com"
+      username="me@mycompany.com"
+      password="secret"
+      port="25"
+      />
+
+    <mail:queuedDelivery
+      permission="zope.SendMail"
+      queuePath="/tmp"
+      mailer="mycompany_smtp"
+      />
+
+    -->
+
+    <utility
+      name="queued_mailer"
+      provides="Products.MailHost.interfaces.IMailHost"
+      factory=".queued_mailhost.QueuedMailHost"
+      />
+      
+  </configure>
+
 </configure>

--- a/Products/EasyNewsletter/content/ENLIssue.py
+++ b/Products/EasyNewsletter/content/ENLIssue.py
@@ -423,13 +423,13 @@ class ENLIssue(ATTopic, atapi.BaseContent):
             outer.attach(text_part)
             outer.attach(html_part)
 
+            msg = outer.as_string()
             try:
-                #MailHost.send(msg)
-                MailHost.send(outer.as_string())
+                MailHost.send(msg, mfrom=sender_email, mto=receiver['email'])
                 log.info("Send newsletter to \"%s\"" % receiver['email'])
                 send_counter += 1
             except AttributeError:  # Plone3.3.x
-                MailHost.send(msg.as_string())
+                MailHost.send(msg, mfrom=sender_email, mto=receiver['email'])
                 log.info("Send newsletter to \"%s\"" % receiver['email'])
                 send_counter += 1
             except Exception, e:
@@ -437,7 +437,6 @@ class ENLIssue(ATTopic, atapi.BaseContent):
                 send_error_counter += 1
 
         log.info("Newsletter was sent to (%s) receivers. (%s) errors occurred!" % (send_counter, send_error_counter))
-
         # change status only for a 'regular' send operation (not 'test', no
         # explicit recipients)
         if not hasattr(request, "test") and not recipients:

--- a/Products/EasyNewsletter/queued_mailhost.py
+++ b/Products/EasyNewsletter/queued_mailhost.py
@@ -39,6 +39,9 @@ def synchronized(lock):
 
 
 class QueuedMailHost(object):
+    """ almost bare c/p of Products.MailHost.MailHost.MailBase
+    which is only available on plone 4
+    """
 
     interface.implements(IMailHost)
 

--- a/Products/EasyNewsletter/queued_mailhost.py
+++ b/Products/EasyNewsletter/queued_mailhost.py
@@ -43,7 +43,7 @@ class QueuedMailHost(object):
     which is only available on plone 4
     """
 
-    interface.implements(IMailHost)
+    implements(IMailHost)
 
     security = ClassSecurityInfo()
     smtp_uid = '' # Class attributes for smooth upgrades

--- a/Products/EasyNewsletter/queued_mailhost.py
+++ b/Products/EasyNewsletter/queued_mailhost.py
@@ -1,0 +1,137 @@
+import logging
+from threading import Lock
+from os.path import realpath
+
+from AccessControl.SecurityInfo import ClassSecurityInfo
+from AccessControl.Permissions import change_configuration, view
+
+from zope.app.component.hooks import getSite
+
+from zope.interface import implements
+
+from zope.sendmail.mailer import SMTPMailer
+from zope.sendmail.maildir import Maildir
+from zope.sendmail.delivery import DirectMailDelivery
+from zope.sendmail.delivery import QueuedMailDelivery
+from zope.sendmail.delivery import QueueProcessorThread
+
+from Products.CMFCore.utils import getToolByName
+from Products.MailHost.interfaces import IMailHost
+
+
+LOG = logging.getLogger('QueuedMailHost')
+
+queue_threads = {}  # maps MailHost path -> queue processor threada
+
+
+def synchronized(lock):
+    """ Decorator for method synchronization. """
+
+    def wrapper(f):
+        def method(*args, **kw):
+            lock.acquire()
+            try:
+                return f(*args, **kw)
+            finally:
+                lock.release()
+        return method
+    return wrapper
+
+
+class QueuedMailHost(object):
+
+    interface.implements(IMailHost)
+
+    security = ClassSecurityInfo()
+    smtp_uid = '' # Class attributes for smooth upgrades
+    smtp_pwd = ''
+    smtp_queue = True
+    smtp_queue_directory = '/tmp'
+    force_tls = False
+    lock = Lock()
+
+    def _makeMailer(self, context=None):
+        """ Create a SMTPMailer """
+        if context is None:
+            context = getSite()
+        mailhost = getToolByName(context,'MailHost')
+        if mailhost:
+            self.smtp_host = mailhost.smtp_host
+            self.smtp_port = mailhost.smtp_port
+            self.smtp_uid = mailhost._smtp_userid
+            self.smtp_pwd = mailhost._smtp_pass
+        return SMTPMailer(hostname=self.smtp_host,
+                          port=int(self.smtp_port),
+                          username=self.smtp_uid or None,
+                          password=self.smtp_pwd or None)
+
+    security.declarePrivate('_getThreadKey')
+    def _getThreadKey(self):
+        """ Return the key used to find our processor thread.
+        """
+        return realpath(self.smtp_queue_directory)
+
+    @synchronized(lock)
+    def _stopQueueProcessorThread(self):
+        """ Stop thread for processing the mail queue.
+        """
+        key = self._getThreadKey()
+        if key in queue_threads:
+            thread = queue_threads[key]
+            thread.stop()
+            while thread.isAlive():
+                # wait until thread is really dead
+                time.sleep(0.3)
+            del queue_threads[key]
+            LOG.info('Thread for %s stopped' % key)
+
+    @synchronized(lock)
+    def _startQueueProcessorThread(self):
+        """ Start thread for processing the mail queue.
+        """
+        key = self._getThreadKey()
+        if key not in queue_threads:
+            thread = QueueProcessorThread()
+            thread.setMailer(self._makeMailer())
+            thread.setQueuePath(self.smtp_queue_directory)
+            thread.start()
+            queue_threads[key] = thread
+        LOG.info('Thread for %s started' % key)
+
+    security.declareProtected(view, 'queueLength')
+    def queueLength(self):
+        """ return length of mail queue """
+        try:
+            maildir = Maildir(self.smtp_queue_directory)
+            return len([item for item in maildir])
+        except ValueError:
+            return 'n/a - %s is not a maildir - please verify your ' \
+                   'configuration' % self.smtp_queue_directory
+
+    security.declareProtected(view, 'queueThreadAlive')
+    def queueThreadAlive(self):
+        """ return True/False is queue thread is working
+        """
+        th = queue_threads.get(self._getThreadKey())
+        if th:
+            return th.isAlive()
+        return False
+
+    security.declarePrivate('_send')
+    def _send(self, mfrom, mto, msg, immediate=False):
+        """ Send the message """
+
+        if self.smtp_queue:
+            # Start queue processor thread, if necessary
+            self._startQueueProcessorThread()
+            delivery = QueuedMailDelivery(self.smtp_queue_directory)
+        else:
+            delivery = DirectMailDelivery(self._makeMailer())
+        delivery.send(mfrom, mto, msg)
+
+    def send(self, msg, mto=[], mfrom="", subject="", encode=None):
+        """Send email
+        """
+        if not isinstance(mto,list):
+            mto = [mto]
+        return self._send(mfrom, mto, msg)

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,7 @@ Requirements
     * inqbus.plone.fastmemberproperties, speed up access of member properties (optional, you can installed it with Products.EasyNewsletter[all] in your buidlout eggs list)
     * Plone 3.X (tested)
     * Plone 4.X (tested)
+    * with Plone 3.X you'll need to pin cssutils==0.9.7
 
 
 Installation


### PR DESCRIPTION
Hi, 
Plone 4 already uses Products.MailHost that uses IQueuedMailDelivery from zope.sendmail allowing mail queue. When you are sending a lot of email this can be very useful.

Newsletter can already use different delivery service trough 'deliveryService' field that looks for IMailHost utilities. I created 'queued_mailhost' utility that is registered *only on plone 3*, which is mainly a bare c/p of what is done into Products.Mailhost.

I'm ok if we don't include this into trunk. In that case I'll split out this code into a separate package.
