### PR TITLE
Fix typo that makes tests fail

### DIFF
--- a/Products/EasyNewsletter/config.py
+++ b/Products/EasyNewsletter/config.py
@@ -125,7 +125,7 @@ img.tileImage {
   <table width="100%" cellpadding="0" cellspaceing="0">
     <tr>
       <td>
-        <div class="mailonlyy"
+        <div class="mailonly"
             tal:define="portal_url context/@@plone_portal_state/portal_url">
           <img src="logo.png" />
         </div>

--- a/Products/EasyNewsletter/tests/test_newsletter.py
+++ b/Products/EasyNewsletter/tests/test_newsletter.py
@@ -85,7 +85,7 @@ class EasyNewsletterTests(unittest.TestCase):
             "ENLIssue",
             id="issue")
         self.newsletter.issue.title="Test Newsletter Issue"
-        self.newsletter.issue.setText("<h1>This is the newsletter body!</h2><div class=\"mailonly\">This test should only visible in mails not in public view!</div>")
+        self.newsletter.issue.setText("<h1>This is the newsletter body!</h1><div class=\"mailonly\">This test should only visible in mails not in public view!</div>")
         view = getMultiAdapter(
             (self.newsletter.issue, self.portal.REQUEST),
             name="get-public-body")


### PR DESCRIPTION
A typo on default template makes 'test_mailonly_filter_in_issue_public_view' fail.
No big deal.
