### PR TITLE
Overhaul in order to simplify workflow, and prepare for multilingual sub...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@ Changelog
 =========
 
 
-2.6.15 (unreleased)
--------------------
+3.0a1 (unreleased)
+------------------
 
 - Fixed jquery initialization in enl_edithelper.js and make it work again.
   It didn't hide the user selection fields.
@@ -36,7 +36,7 @@ Changelog
   affected files to look up those constants.
   [benniboy]
 
-- Fixed A subscriber can now unsubscribe himself, if he is not logged in.
+- Fixed a subscriber can now unsubscribe himself, if he is not logged in.
   [benniboy]
 
 - Reworked the salutation mapping (prepared for multilingual newsletter)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,41 @@ Changelog
 2.6.15 (unreleased)
 -------------------
 
-- fixed jquery initialization in enl_edithelper.js
+- Fixed jquery initialization in enl_edithelper.js and make it work again.
+  It didn't hide the user selection fields.
+  [benniboy]
+
+- Status and error messsages show up for anon users (was broke).
+  [benniboy]
+
+- Implemented that subscribers and recipients have a language. This is also
+  queable via index and the affecting page templates have been adjusted.
+  [benniboy]
+
+- Made a checkbox in the send issue form to exclude all external subscribers.
+  [benniboy]
+
+- Split up the send method for better hookability.
+  [benniboy]
+
+- Reworked the whole issue workflow. See README.
+  [benniboy]
+
+- Added info on several newsletter fields, that changing settings does not
+  affect already existing issues for that newsletter.
+  [benniboy]
+
+- Fixed enl_edithelper.py work again.
+  [benniboy]
+
+- Added 2 new constants to the config.py for hookability and adjusted the
+  affected files to look up those constants.
+  [benniboy]
+
+- Fixed A subscriber can now unsubscribe himself, if he is not logged in.
+  [benniboy]
+
+- Reworked the salutation mapping (prepared for multilingual newsletter)
   [benniboy]
 
 - Added utf-8 headers, sorted imports (plone-style), lines down to 80 chars.

--- a/Products/EasyNewsletter/TODO.txt
+++ b/Products/EasyNewsletter/TODO.txt
@@ -1,8 +1,8 @@
 #TODO:
-    
+
     * hide ENLTemplate from navigation
 
-    * add validator to ENLSubsciber to check if this email already exists, 
+    * add validator to ENLSubsciber to check if this email already exists,
       works now only for the portlet, but not if we use the add item menu. [derstappenit]
 
     * provide default values for sender_name, sender_address and test_email from portal_properties
@@ -11,4 +11,6 @@
 
     * move the send method and all other stuff, which is not releated to the ENLIssue it self into a z3 global utility
 
-    * log sending messages "send to max@example.com: OK" into the issue object, provide a view to show the log   
+    * log sending messages "send to max@example.com: OK" into the issue object, provide a view to show the log
+
+    * add languagesupport for csv import and export

--- a/Products/EasyNewsletter/browser/configure.zcml
+++ b/Products/EasyNewsletter/browser/configure.zcml
@@ -41,6 +41,20 @@
     template="issue_public_view.pt"
     permission="zope2.View" />
 
+  <browser:page
+    name="copy-as-draft"
+    for="..interfaces.IENLIssue"
+    class=".issue.IssueView"
+    attribute="copy_as_draft"
+    permission="cmf.ModifyPortalContent" />
+
+  <browser:page
+    name="copy-as-master"
+    for="..interfaces.IENLIssue"
+    class=".issue.IssueView"
+    attribute="copy_as_master"
+    permission="cmf.ModifyPortalContent" />
+
  <browser:page
     name="daily-issue"
     for="..interfaces.IEasyNewsletter"
@@ -122,5 +136,11 @@
     name="Products.EasyNewsletter.enl_edithelper.js"
       file="javascripts/enl_edithelper.js" />
 
+  <browser:page
+    name="load_enl_edithelper"
+    class=".edithelper.EditHelperView"
+    attribute="enable"
+    permission="zope.Public"
+    for="*" />
 
 </configure>

--- a/Products/EasyNewsletter/browser/configure.zcml
+++ b/Products/EasyNewsletter/browser/configure.zcml
@@ -46,14 +46,14 @@
     for="..interfaces.IENLIssue"
     class=".issue.IssueView"
     attribute="copy_as_draft"
-    permission="cmf.ModifyPortalContent" />
+    permission="zope2.CopyOrMove" />
 
   <browser:page
     name="copy-as-master"
     for="..interfaces.IENLIssue"
     class=".issue.IssueView"
     attribute="copy_as_master"
-    permission="cmf.ModifyPortalContent" />
+    permission="zope2.CopyOrMove" />
 
  <browser:page
     name="daily-issue"

--- a/Products/EasyNewsletter/browser/edithelper.py
+++ b/Products/EasyNewsletter/browser/edithelper.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from Products.Five.browser import BrowserView
+from Products.EasyNewsletter.config import ENL_EDITHELPER_TYPES
+
+
+class EditHelperView(BrowserView):
+    """
+    """
+    def enable(self):
+        return self.context.portal_type in ENL_EDITHELPER_TYPES

--- a/Products/EasyNewsletter/browser/edithelper.py
+++ b/Products/EasyNewsletter/browser/edithelper.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from Products.Five.browser import BrowserView
 from Products.EasyNewsletter.config import ENL_EDITHELPER_TYPES
+from Products.Five.browser import BrowserView
 
 
 class EditHelperView(BrowserView):

--- a/Products/EasyNewsletter/browser/enl_subscribers_view.pt
+++ b/Products/EasyNewsletter/browser/enl_subscribers_view.pt
@@ -43,6 +43,10 @@
                   <span class="label" i18n:translate="fullname">Fullname:</span>
                   <input type="text" name="fullname"
                          tal:attributes="value request/fullname|nothing" /><br />
+                  <span class="label" i18n:translate="language">Language:</span>
+                  <input type="text" name="Newsletter language"
+                         tal:attributes="value request/nl_language|nothing" /><br />
+
                   <span class="label" i18n:translate="organization">Organization:</span>
                   <input type="text" name="organization"
                          tal:attributes="value request/organization|nothing" /><br />
@@ -72,7 +76,7 @@
 
               <table class="listing" summary="Subscriber Listing">
                   <tr>
-                    <th colspan="7">
+                    <th colspan="8">
                       <span class="total" i18n:translate="">
                         There are
                         <span i18n:name="subscribers_count"
@@ -88,6 +92,7 @@
                       <th i18n:translate="mail">Email</th>
                       <th i18n:translate="salutation">Salutation</th>
                       <th i18n:translate="name">Name</th>
+                      <th i18n:translate="language">Language</th>
                       <th i18n:translate="organization">Company/Organization</th>
                       <th i18n:translate="source">Source</th>
                       <th i18n:translate="action">Action</th>
@@ -113,6 +118,7 @@
                       </td>
                       <td i18n:translate="" tal:content="subscriber/salutation" />
                       <td i18n:translate="" tal:content="subscriber/fullname" />
+                      <td i18n:translate="" tal:content="subscriber/nl_language|nothing" />
                       <td i18n:translate="" tal:content="subscriber/organization|nothing"></td>
                       <td i18n:translate="" tal:content="subscriber/source|nothing"></td>
                       <td>
@@ -141,7 +147,7 @@
               </div>
             </form>
 
-            
+
 
         </div>
 

--- a/Products/EasyNewsletter/browser/issue.py
+++ b/Products/EasyNewsletter/browser/issue.py
@@ -6,6 +6,7 @@ from Products.EasyNewsletter.config import PLACEHOLDERS
 from Products.Five.browser import BrowserView
 from plone import api
 
+
 class IssueView(BrowserView):
     """
     """
@@ -36,7 +37,6 @@ class IssueView(BrowserView):
             node.extract()
         return soup.renderContents()
 
-
     def copy_as_draft(self):
         newsletter = self.context.aq_parent
         master_id = self.context.getId()
@@ -56,7 +56,6 @@ class IssueView(BrowserView):
         return self.request.response.redirect(
             draft_obj.absolute_url() + '/edit'
         )
-
 
     def copy_as_master(self):
         request = self.context.REQUEST

--- a/Products/EasyNewsletter/browser/issue_send_form.pt
+++ b/Products/EasyNewsletter/browser/issue_send_form.pt
@@ -20,7 +20,7 @@
   <br/>
   <form tal:attributes="action string:${context/absolute_url}/send-issue"
         tal:define="wtool context/@@plone_tools/workflow;
-                    sent python:wtool.getInfoFor(context, 'review_state') == 'sent'"
+                    sent python:wtool.getInfoFor(context, 'review_state') in ['sent', 'master'] "
         method="post"
         id="issue_send_form">
 

--- a/Products/EasyNewsletter/browser/javascripts/enl_edithelper.js
+++ b/Products/EasyNewsletter/browser/javascripts/enl_edithelper.js
@@ -1,24 +1,26 @@
 var jq = $;
 
 jq(document).ready(function(){
+    var members = "#archetypes-fieldname-ploneReceiverMembers";
+    var groups = "#archetypes-fieldname-ploneReceiverGroups";
+
 	if (jq("#sendToAllPloneMembers").attr('checked')){
-		jq("#archetypes-fieldname-ploneReceiverMembers").addClass('hidden')
-		jq("#archetypes-fieldname-ploneReceiverGroups").addClass('hidden')
+		jq(members).css('visibility', 'hidden');
+		jq(groups).css('visibility', 'hidden');
 	}else{
-		jq("#archetypes-fieldname-ploneReceiverMembers").removeClass('hidden')
-		jq("#archetypes-fieldname-ploneReceiverGroups").removeClass('hidden')
-	};
+		jq(members).css('visibility', 'visible');
+		jq(groups).css('visibility', 'visible');
+	}
 	jq("#sendToAllPloneMembers").click(function (){
 		if (jq(this).attr('checked')){
-			jq("#archetypes-fieldname-ploneReceiverMembers").addClass('hidden')
-			jq("#archetypes-fieldname-ploneReceiverGroups").addClass('hidden')
+			jq(members).css('visibility', 'hidden');
+			jq(groups).css('visibility', 'hidden');
 		}else{
-			jq("#archetypes-fieldname-ploneReceiverMembers").removeClass('hidden')
-			jq("#archetypes-fieldname-ploneReceiverGroups").removeClass('hidden')
+			jq(members).css('visibility', 'visible');
+			jq(groups).css('visibility', 'visible');
 		}
 	});
 });
-
 
 /*
   jq("#archetypes-fieldname-header").insertAfter("\

--- a/Products/EasyNewsletter/browser/newsletter.py
+++ b/Products/EasyNewsletter/browser/newsletter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
-from Products.Five.browser import BrowserView
 from Products.EasyNewsletter.config import ENL_ISSUE_TYPES
+from Products.Five.browser import BrowserView
 
 class NewsletterView(BrowserView):
     """

--- a/Products/EasyNewsletter/browser/newsletter.py
+++ b/Products/EasyNewsletter/browser/newsletter.py
@@ -3,10 +3,10 @@ from Products.CMFCore.utils import getToolByName
 from Products.EasyNewsletter.config import ENL_ISSUE_TYPES
 from Products.Five.browser import BrowserView
 
+
 class NewsletterView(BrowserView):
     """
     """
-
     def getRenderedIssues(self):
         """ Return the rendered body of all newsletter issues """
 

--- a/Products/EasyNewsletter/browser/newsletter.py
+++ b/Products/EasyNewsletter/browser/newsletter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
-
+from Products.EasyNewsletter.config import ENL_ISSUE_TYPES
 
 class NewsletterView(BrowserView):
     """
@@ -12,7 +12,7 @@ class NewsletterView(BrowserView):
 
         result = list()
         catalog = getToolByName(self.context, "portal_catalog")
-        for brain in catalog(portal_type='ENLIssue',
+        for brain in catalog(portal_type=ENL_ISSUE_TYPES,
                              path='/'.join(self.context.getPhysicalPath())):
             issue = brain.getObject()
             content = issue.restrictedTraverse('@@get-public-body')()

--- a/Products/EasyNewsletter/browser/registration.py
+++ b/Products/EasyNewsletter/browser/registration.py
@@ -68,22 +68,23 @@ class SubscriberView(BrowserView):
         newsletter_container = self.portal.unrestrictedTraverse(
             path_to_easynewsletter)
         messages = IStatusMessage(self.request)
+
         if not subscriber:
             messages.addStatusMessage(
                 _("Please enter a valid email address."), "error")
-            self._msg_redirect(newsletter_container)
+            return self._msg_redirect(newsletter_container)
 
         mo = re.search(EMAIL_RE, subscriber)
         if not mo:
             messages.addStatusMessage(
                 _("Please enter a valid email address."), "error")
-            self._msg_redirect(newsletter_container)
+            return self._msg_redirect(newsletter_container)
         norm = queryUtility(IIDNormalizer)
         normalized_subscriber = norm.normalize(subscriber)
         if normalized_subscriber in newsletter_container.objectIds():
             messages.addStatusMessage(
                 _("Your email address is already registered."), "error")
-            self._msg_redirect(newsletter_container)
+            return self._msg_redirect(newsletter_container)
         subscriber_data = {}
         subscriber_data["subscriber"] = subscriber
         subscriber_data["fullname"] = fullname
@@ -124,7 +125,7 @@ class SubscriberView(BrowserView):
                 A confirmation email was sent to your address. Please check \
                 your inbox and click on the link in the email in order to \
                 confirm your subscription."), "info")
-            self._msg_redirect(newsletter_container)
+            return self._msg_redirect(newsletter_container)
 
     def confirm_subscriber(self):
         hashkey = self.request.get('hkey')

--- a/Products/EasyNewsletter/browser/registration.py
+++ b/Products/EasyNewsletter/browser/registration.py
@@ -7,6 +7,7 @@ from Products.EasyNewsletter.config import MESSAGE_CODE
 from Products.EasyNewsletter.interfaces import IENLRegistrationTool
 from Products.Five.browser import BrowserView
 from Products.statusmessages.interfaces import IStatusMessage
+from Products.validation.validators.BaseValidators import EMAIL_RE
 from email.MIMEText import MIMEText
 from plone import api
 from plone.i18n.normalizer.interfaces import IIDNormalizer
@@ -14,10 +15,8 @@ from zope.component import getMultiAdapter
 from zope.component import queryUtility
 import OFS
 import re
-from plone import api
-from Products.validation.validators.BaseValidators import EMAIL_RE
-EMAIL_RE = "^" + EMAIL_RE
 
+EMAIL_RE = "^" + EMAIL_RE
 
 
 class SubscriberView(BrowserView):
@@ -33,7 +32,6 @@ class SubscriberView(BrowserView):
         else:
             return self.request.response.redirect(
                 newsletter.absolute_url())
-
 
     def portal_state(self):
         context = aq_inner(self.context)
@@ -98,10 +96,6 @@ class SubscriberView(BrowserView):
         hashkey = pwr_data['randomstring']
         enl_registration_tool = queryUtility(
             IENLRegistrationTool, 'enl_registration_tool')
-        # todo die register mail und  status msg geht immer raus, auch wenns eigentlich
-        # abbrechen sollte wenn zb die email schon confirmed ist - prob bei self._requestReset(subscriber)??
-        # bzw wird ja immer ein neuer hashkey generiert und glaube daher gehört hier nochn check rein
-        #is anon und logged in das selbe
         if hashkey not in enl_registration_tool.objectIds():
             enl_registration_tool[hashkey] = RegistrationData(
                 hashkey, **subscriber_data)

--- a/Products/EasyNewsletter/browser/registration.py
+++ b/Products/EasyNewsletter/browser/registration.py
@@ -28,7 +28,8 @@ class SubscriberView(BrowserView):
         """
         if api.user.is_anonymous():
             return self.request.response.redirect(
-                    self.context.absolute_url())
+                self.context.absolute_url()
+            )
         else:
             return self.request.response.redirect(
                 newsletter.absolute_url())

--- a/Products/EasyNewsletter/browser/subscribers.py
+++ b/Products/EasyNewsletter/browser/subscribers.py
@@ -87,7 +87,7 @@ def normalize_id(astring):
 
 
 CSV_HEADER = [
-    _(u"salutation"), _(u"fullname"), _(u"email"), _(u"organization")]
+    _(u"salutation"), _(u"fullname"), _(u"nl_lang"), _(u"email"), _(u"organization")]
 
 
 class IEnl_Subscribers_View(Interface):
@@ -242,23 +242,25 @@ class UploadCSV(BrowserView):
 
         for subscriber in reader:
             # Check the length of the line
-            if len(subscriber) != 4:
+            if len(subscriber) != 5:
                 msg = _('The number of items in the line is not correct. \
-                        It should be 4. Check your CSV file.')
+                        It should be 5. Check your CSV file.')
                 fail.append(
                     {'failure': msg})
             else:
 
                 salutation = subscriber[0]
                 fullname = subscriber[1]
-                email = subscriber[2]
-                organization = subscriber[3]
+                nl_lang = subscriber[2]
+                email = subscriber[3]
+                organization = subscriber[4]
                 id = normalize_id(email)
                 if id in existing:
                     msg = _('This email address is already registered.')
                     fail.append(
                         {'salutation': salutation,
                          'fullname': fullname,
+                         'nl_lang': nl_lang,
                          'email': email,
                          'organization': organization,
                          'failure': msg})
@@ -274,6 +276,7 @@ class UploadCSV(BrowserView):
                         sub = context[id]
                         sub.email = email
                         sub.fullname = fullname
+                        sub.nl_language = nl_lang
                         sub.organization = organization
                         sub.salutation = salutation
                         obj = self.context.get(id, None)
@@ -283,6 +286,7 @@ class UploadCSV(BrowserView):
                         success.append({
                             'salutation': salutation,
                             'fullname': fullname,
+                            'nl_lang': nl_lang,
                             'email': email,
                             'organization': organization
                         })
@@ -290,6 +294,7 @@ class UploadCSV(BrowserView):
                         fail.append({
                             'salutation': salutation,
                             'fullname': fullname,
+                            'nl_lang': nl_lang,
                             'email': email,
                             'organization': organization,
                             'failure': (

--- a/Products/EasyNewsletter/browser/subscribers.py
+++ b/Products/EasyNewsletter/browser/subscribers.py
@@ -104,7 +104,7 @@ class Enl_Subscribers_View(BrowserView):
 
     # TODO: we should move these indexes from FieldIndex to ZCTextIndex
     # see setuphandlers.py for indexes creation
-    searchable_params = ('email', 'fullname', 'organization')
+    searchable_params = ('email', 'fullname', 'nl_language', 'organization')
 
     def __init__(self, context, request):
         self.context = context
@@ -145,7 +145,6 @@ class Enl_Subscribers_View(BrowserView):
                 salutation = SALUTATION.getValue(brain.salutation, '')
             else:
                 salutation = ''
-
             subscribers.append(dict(
                 id=brain.getId,
                 source='plone',
@@ -154,6 +153,7 @@ class Enl_Subscribers_View(BrowserView):
                 getURL=brain.getURL(),
                 salutation=salutation,
                 fullname=brain.fullname,
+                nl_language=brain.nl_language,
                 organization=brain.organization
             ))
 

--- a/Products/EasyNewsletter/browser/templates/enl_actions_viewlet.pt
+++ b/Products/EasyNewsletter/browser/templates/enl_actions_viewlet.pt
@@ -1,16 +1,20 @@
-<ul id="enl_actions" 
+<ul id="enl_actions"
     i18n:domain="EasyNewsletter">
   <li><a tal:attributes="href string:${view/enl_url}/easynewsletter_view;"
       title="Issue archive"
       i18n:attributes="title"
       i18n:translate="">Archive</a></li>
   <li><a tal:attributes="href string:${view/enl_url}/enl_drafts_view;"
-      title="Issue drafts" 
+      title="Issue drafts"
       i18n:attributes="title"
       i18n:translate="">Drafts</a></li>
+   <li><a tal:attributes="href string:${view/enl_url}/enl_masters_view;"
+      title="Issue masters"
+      i18n:attributes="title"
+      i18n:translate="">Masters</a></li>
   <li><a tal:attributes="href string:${view/enl_url}/enl_subscribers_view;"
       title="Subscriberlist"
       i18n:attributes="title"
       i18n:translate="">Subscribers</a></li>
-</ul> 
+</ul>
 

--- a/Products/EasyNewsletter/config.py
+++ b/Products/EasyNewsletter/config.py
@@ -7,6 +7,8 @@ import re
 
 PROJECTNAME = "EasyNewsletter"
 
+ENL_ISSUE_TYPES = ['ENLIssue']
+ENL_EDITHELPER_TYPES =['EasyNewsletter', 'ENLIssue']
 
 PLACEHOLDERS = ["UNSUBSCRIBE", "SUBSCRIBER_SALUTATION"]
 
@@ -17,6 +19,12 @@ SALUTATION = DisplayList((
     ("mr", _(u"label_salutation_mr", "Mr.")),
 ))
 
+NL_LANGUAGE = DisplayList((
+    ('', _(u"label_choose_nl_language", "Choose language...")),
+    ("de", _(u"label_salutation_de", "DE")),
+    ("en", _(u"label_salutation_de", "EN")),
+    ("fr", _(u"label_salutation_de", "FR")),
+))
 
 MESSAGE_CODE = {
     "email_added": _(

--- a/Products/EasyNewsletter/config.py
+++ b/Products/EasyNewsletter/config.py
@@ -15,7 +15,7 @@ PLACEHOLDERS = ["UNSUBSCRIBE", "SUBSCRIBER_SALUTATION"]
 
 SALUTATION = DisplayList((
     ('', _(u"label_choose_saluation", "Choose salutation...")),
-    ("ms", _(u"label_salutation_ms", "Ms.")),
+    ("ms", _(u"label_salutation_mrs", "Mrs.")),
     ("mr", _(u"label_salutation_mr", "Mr.")),
 ))
 
@@ -229,7 +229,7 @@ DEFAULT_SUBSCRIBER_CONFIRMATION_MAIL_SUBJECT = _(
 )
 
 DEFAULT_SUBSCRIBER_CONFIRMATION_MAIL_TEXT = """\
-You subscribe to the ${newsletter_title} Newsletter.\n\n
+You subscribe to the ${newsletter_title}.\n\n
 Your registered email is: ${subscriber_email}\n
 Please click on the link to confirm your subscription: \n
 ${confirmation_url}"""

--- a/Products/EasyNewsletter/content/ENLIssue.py
+++ b/Products/EasyNewsletter/content/ENLIssue.py
@@ -678,7 +678,9 @@ class ENLIssue(ATTopic, atapi.BaseContent):
                 probdict['email'] = member.getProperty('email')
                 probdict['gender'] = member.getProperty('nl_gender')
                 # try last name first
-                probdict['fullname'] = member.getProperty('last_name','fullname')
+                probdict['fullname'] = \
+                    member.getProperty('last_name',
+                                       member.getProperty('fullname'))
                 probdict['language'] = member.getProperty('language')
                 # fallback for default plone users without a enl language
                 if not probdict['language']:

--- a/Products/EasyNewsletter/content/ENLIssue.py
+++ b/Products/EasyNewsletter/content/ENLIssue.py
@@ -293,7 +293,7 @@ class ENLIssue(ATTopic, atapi.BaseContent):
                         'salutation': salutation.get(
                             subscriber.getNl_language(),
                             salutation.get(self.Language() or 'en', 'unset')
-                            ),
+                        ),
                         'uid': subscriber.UID(),
                         'nl_language': subscriber.getNl_language()})
 
@@ -463,7 +463,6 @@ class ENLIssue(ATTopic, atapi.BaseContent):
                 wftool.doActionFor(self, "send")
             request['enlwf_guard'] = False
 
-
     def _get_issue_data(self, receiver):
         """
         returns a dict of issue_data, like subject and several parts of
@@ -490,7 +489,6 @@ class ENLIssue(ATTopic, atapi.BaseContent):
         issue_data['images_to_attach'] = self._get_images_to_attach(image_urls)
 
         return issue_data
-
 
     def _personalize_texts(self, enl, receiver, text, text_plain):
         salutation = receiver.get("salutation") or ''
@@ -680,7 +678,7 @@ class ENLIssue(ATTopic, atapi.BaseContent):
                 probdict['email'] = member.getProperty('email')
                 probdict['fullname'] = member.getProperty('fullname')
                 probdict['language'] = member.getProperty('language')
-                #fallback for default plone users without a enl language
+                # fallback for default plone users without a enl language
                 if not probdict['language']:
                     probdict['language'] = self.Language()
                 member_properties[probdict['id']] = probdict
@@ -712,7 +710,7 @@ class ENLIssue(ATTopic, atapi.BaseContent):
                     'salutation': salutation.get(
                         member_property.get('language', ''),
                         salutation.get(self.Language() or 'en', 'unset')
-                        ),
+                    ),
                     'nl_language': member_property.get('language', '')
                 })
             else:

--- a/Products/EasyNewsletter/content/ENLIssue.py
+++ b/Products/EasyNewsletter/content/ENLIssue.py
@@ -677,7 +677,8 @@ class ENLIssue(ATTopic, atapi.BaseContent):
                 probdict['id'] = member.getUserId()
                 probdict['email'] = member.getProperty('email')
                 probdict['gender'] = member.getProperty('nl_gender')
-                probdict['fullname'] = member.getProperty('fullname')
+                # try last name first
+                probdict['fullname'] = member.getProperty('last_name','fullname')
                 probdict['language'] = member.getProperty('language')
                 # fallback for default plone users without a enl language
                 if not probdict['language']:

--- a/Products/EasyNewsletter/content/ENLIssue.py
+++ b/Products/EasyNewsletter/content/ENLIssue.py
@@ -676,6 +676,7 @@ class ENLIssue(ATTopic, atapi.BaseContent):
                 probdict = {}
                 probdict['id'] = member.getUserId()
                 probdict['email'] = member.getProperty('email')
+                probdict['gender'] = member.getProperty('nl_gender')
                 probdict['fullname'] = member.getProperty('fullname')
                 probdict['language'] = member.getProperty('language')
                 # fallback for default plone users without a enl language

--- a/Products/EasyNewsletter/content/ENLSubscriber.py
+++ b/Products/EasyNewsletter/content/ENLSubscriber.py
@@ -35,6 +35,20 @@ schema = atapi.BaseSchema + atapi.Schema((
     ),
 
     atapi.StringField(
+        'nl_language',
+        required=False,
+        vocabulary=config.NL_LANGUAGE,
+        widget=atapi.SelectionWidget(
+            label=_(
+                u'EasyNewsletter_label_help_nl_language',
+                default='Newsletter language'),
+            description=_('EasyNewsletter_help_nl_language', default=u''),
+            i18n_domain='EasyNewsletter',
+            format='select',
+        ),
+    ),
+
+    atapi.StringField(
         'fullname',
         required=False,
         widget=atapi.StringWidget(

--- a/Products/EasyNewsletter/content/EasyNewsletter.py
+++ b/Products/EasyNewsletter/content/EasyNewsletter.py
@@ -225,9 +225,9 @@ schema = atapi.Schema((
                 default=u"Plone Groups to receive the newsletter"),
             description=_(
                 u"EasyNewsletter_help_ploneReceiverGroups",
-                default=u"Choose Plone Groups which members should "
-                    "receive the newsletter. Changing this setting does not "
-                    "affect already existing issues."),
+                default=u"Choose Plone Groups which members should \
+                    receive the newsletter. Changing this setting does not \
+                    affect already existing issues."),
             i18n_domain='EasyNewsletter',
             size=10,
         )

--- a/Products/EasyNewsletter/i18n/easynewsletter.pot
+++ b/Products/EasyNewsletter/i18n/easynewsletter.pot
@@ -810,9 +810,9 @@ msgstr ""
 msgid "label_salutation_mr"
 msgstr ""
 
-#. Default: "Ms."
+#. Default: "Mrs."
 #: ../config.py:14
-msgid "label_salutation_ms"
+msgid "label_salutation_mrs"
 msgstr ""
 
 #. Default: "Select all items"

--- a/Products/EasyNewsletter/locales/EasyNewsletter.pot
+++ b/Products/EasyNewsletter/locales/EasyNewsletter.pot
@@ -825,9 +825,9 @@ msgstr ""
 msgid "label_salutation_mr"
 msgstr ""
 
-#. Default: "Ms."
+#. Default: "Mrs."
 #: ./config.py:16
-msgid "label_salutation_ms"
+msgid "label_salutation_mrs"
 msgstr ""
 
 #. Default: "Select all items"

--- a/Products/EasyNewsletter/locales/da/LC_MESSAGES/EasyNewsletter.po
+++ b/Products/EasyNewsletter/locales/da/LC_MESSAGES/EasyNewsletter.po
@@ -836,9 +836,9 @@ msgstr "Udgående mail-skabelon"
 msgid "label_salutation_mr"
 msgstr "Hr"
 
-#. Default: "Ms."
+#. Default: "Mrs."
 #: ./config.py:16
-msgid "label_salutation_ms"
+msgid "label_salutation_mrs"
 msgstr "Fru"
 
 #. Default: "Select all items"

--- a/Products/EasyNewsletter/locales/de/LC_MESSAGES/EasyNewsletter.po
+++ b/Products/EasyNewsletter/locales/de/LC_MESSAGES/EasyNewsletter.po
@@ -834,9 +834,9 @@ msgstr "Newsletter-Ausgabe-Template"
 msgid "label_salutation_mr"
 msgstr "Herr"
 
-#. Default: "Ms."
+#. Default: "Mrs."
 #: ./config.py:16
-msgid "label_salutation_ms"
+msgid "label_salutation_mrs"
 msgstr "Frau"
 
 #. Default: "Select all items"

--- a/Products/EasyNewsletter/locales/en/LC_MESSAGES/EasyNewsletter.po
+++ b/Products/EasyNewsletter/locales/en/LC_MESSAGES/EasyNewsletter.po
@@ -825,9 +825,9 @@ msgstr ""
 msgid "label_salutation_mr"
 msgstr ""
 
-#. Default: "Ms."
+#. Default: "Mrs."
 #: ./config.py:16
-msgid "label_salutation_ms"
+msgid "label_salutation_mrs"
 msgstr ""
 
 #. Default: "Select all items"

--- a/Products/EasyNewsletter/locales/es/LC_MESSAGES/EasyNewsletter.po
+++ b/Products/EasyNewsletter/locales/es/LC_MESSAGES/EasyNewsletter.po
@@ -837,9 +837,9 @@ msgstr "Plantilla del correo saliente"
 msgid "label_salutation_mr"
 msgstr "Sr."
 
-#. Default: "Ms."
+#. Default: "Mrs."
 #: ./config.py:16
-msgid "label_salutation_ms"
+msgid "label_salutation_mrs"
 msgstr "Srta."
 
 #. Default: "Select all items"

--- a/Products/EasyNewsletter/locales/fr/LC_MESSAGES/EasyNewsletter.po
+++ b/Products/EasyNewsletter/locales/fr/LC_MESSAGES/EasyNewsletter.po
@@ -509,7 +509,7 @@ msgstr "Vous avez été désabonné(e)."
 
 #: ./browser/templates/unsubscribe_form.pt:16
 msgid "You want to unsubscribe from this Newsletter?"
-msgstr ""
+msgstr "Vous désirez vous désabonner de cette lettre?"
 
 #: ./browser/registration.py:217
 msgid "Your email address could not be found in subscribers."
@@ -525,7 +525,7 @@ msgstr "Votre email a été enregistré. Un message de confirmation vous a été
 
 #: ./browser/templates/unsubscribe_form.pt:19
 msgid "Your registered E-Mail address:"
-msgstr ""
+msgstr "Votre adresse E-mail enregistrée:"
 
 #: ./browser/registration.py:129
 msgid "Your subscription was successfully confirmed."
@@ -543,7 +543,7 @@ msgstr "ajouter un abonné"
 
 #: ./browser/templates/unsubscribe_form.pt:25
 msgid "cancel"
-msgstr ""
+msgstr "Annuler"
 
 #: ./browser/registration.py:209
 msgid "confirm newsletter unsubscription"
@@ -694,7 +694,7 @@ msgstr "Tester la lettre"
 #. Default: "Unsubscribe"
 #: ./browser/templates/unsubscribe_form.pt:23
 msgid "easynewsletter_unsubscribe_button"
-msgstr ""
+msgstr "Désabonner"
 
 #: ./browser/subscribers.py:93
 #: ./browser/upload_csv.pt:38
@@ -840,9 +840,9 @@ msgstr "Modèle de la lettre envoyée"
 msgid "label_salutation_mr"
 msgstr "Monsieur"
 
-#. Default: "Ms."
+#. Default: "Mrs."
 #: ./config.py:16
-msgid "label_salutation_ms"
+msgid "label_salutation_mrs"
 msgstr "Madame"
 
 #. Default: "Select all items"
@@ -969,5 +969,5 @@ msgstr "Remonter"
 
 #: ./portlets/subscriber.pt:69
 msgid "unsubscribe"
-msgstr ""
+msgstr "Désabonner"
 

--- a/Products/EasyNewsletter/locales/it/LC_MESSAGES/EasyNewsletter.po
+++ b/Products/EasyNewsletter/locales/it/LC_MESSAGES/EasyNewsletter.po
@@ -829,7 +829,7 @@ msgstr ""
 #. Default: "Mr."
 #: ./config.py:17
 msgid "label_salutation_mr"
-msgstr "Signor"
+msgstr "Signore"
 
 #. Default: "Mrs."
 #: ./config.py:16

--- a/Products/EasyNewsletter/locales/it/LC_MESSAGES/EasyNewsletter.po
+++ b/Products/EasyNewsletter/locales/it/LC_MESSAGES/EasyNewsletter.po
@@ -504,7 +504,7 @@ msgstr "La tua registrazione è stata annullata."
 
 #: ./browser/templates/unsubscribe_form.pt:16
 msgid "You want to unsubscribe from this Newsletter?"
-msgstr ""
+msgstr "Si desidera annullare l'iscrizione a questa newsletter?"
 
 #: ./browser/registration.py:217
 msgid "Your email address could not be found in subscribers."
@@ -520,7 +520,7 @@ msgstr "La tua email è stata registrata. Un'email di conferma è stata inviata 
 
 #: ./browser/templates/unsubscribe_form.pt:19
 msgid "Your registered E-Mail address:"
-msgstr ""
+msgstr "Il tuo indirizzo e-mail registrato"
 
 #: ./browser/registration.py:129
 msgid "Your subscription was successfully confirmed."
@@ -538,7 +538,7 @@ msgstr ""
 
 #: ./browser/templates/unsubscribe_form.pt:25
 msgid "cancel"
-msgstr ""
+msgstr "Annullare"
 
 #: ./browser/registration.py:209
 msgid "confirm newsletter unsubscription"
@@ -687,7 +687,7 @@ msgstr ""
 #. Default: "Unsubscribe"
 #: ./browser/templates/unsubscribe_form.pt:23
 msgid "easynewsletter_unsubscribe_button"
-msgstr ""
+msgstr "Cancellati"
 
 #: ./browser/subscribers.py:93
 #: ./browser/upload_csv.pt:38
@@ -831,9 +831,9 @@ msgstr ""
 msgid "label_salutation_mr"
 msgstr "Signor"
 
-#. Default: "Ms."
+#. Default: "Mrs."
 #: ./config.py:16
-msgid "label_salutation_ms"
+msgid "label_salutation_mrs"
 msgstr "Signora"
 
 #. Default: "Select all items"
@@ -960,5 +960,5 @@ msgstr ""
 
 #: ./portlets/subscriber.pt:69
 msgid "unsubscribe"
-msgstr ""
+msgstr "Cancellati"
 

--- a/Products/EasyNewsletter/locales/nl/LC_MESSAGES/EasyNewsletter.po
+++ b/Products/EasyNewsletter/locales/nl/LC_MESSAGES/EasyNewsletter.po
@@ -835,9 +835,9 @@ msgstr "Uitgaande mail-template"
 msgid "label_salutation_mr"
 msgstr "Mr."
 
-#. Default: "Ms."
+#. Default: "Mrs."
 #: ./config.py:16
-msgid "label_salutation_ms"
+msgid "label_salutation_mrs"
 msgstr "Mevr."
 
 #. Default: "Select all items"

--- a/Products/EasyNewsletter/locales/pt_BR/LC_MESSAGES/EasyNewsletter.po
+++ b/Products/EasyNewsletter/locales/pt_BR/LC_MESSAGES/EasyNewsletter.po
@@ -835,9 +835,9 @@ msgstr "Template do email de saída"
 msgid "label_salutation_mr"
 msgstr "Sr."
 
-#. Default: "Ms."
+#. Default: "Mrs."
 #: ./config.py:16
-msgid "label_salutation_ms"
+msgid "label_salutation_mrs"
 msgstr "Sra."
 
 #. Default: "Select all items"

--- a/Products/EasyNewsletter/portlets/configure.zcml
+++ b/Products/EasyNewsletter/portlets/configure.zcml
@@ -1,16 +1,16 @@
-<configure 
+<configure
   xmlns="http://namespaces.zope.org/zope"
   xmlns:browser="http://namespaces.zope.org/browser"
   xmlns:plone="http://namespaces.plone.org/plone">
-    
+
   <include package="plone.app.portlets" />
-        
+
   <plone:portlet
     name="portlets.Subscriber"
     interface=".subscriber.INewsletterSubscriberPortlet"
     assignment=".subscriber.Assignment"
-    renderer=".subscriber.Renderer"        
-    addview=".subscriber.AddForm" 
+    renderer=".subscriber.Renderer"
+    addview=".subscriber.AddForm"
     editview=".subscriber.EditForm" />
 
 </configure>

--- a/Products/EasyNewsletter/portlets/subscriber.pt
+++ b/Products/EasyNewsletter/portlets/subscriber.pt
@@ -29,15 +29,13 @@
                   name="salutation"
                   value="ms"
                   id="ms">
-              <label for="ms" i18n:translate="ms"> </label>
+              <label for="ms" i18n:translate="ms">ms</label>
               <input
                   type="radio"
                   name="salutation"
                   value="mr"
                   id="mr">
-              <label for="mr" i18n:translate="mr"> </label>
-
-
+              <label for="mr" i18n:translate="mr">mr</label>
             <input class="easynewsletter_text"
                    onclick="this.value=''"
                    name="fullname"

--- a/Products/EasyNewsletter/profiles/default/catalog.xml
+++ b/Products/EasyNewsletter/profiles/default/catalog.xml
@@ -6,6 +6,7 @@
        See add_catalog_indexes in setuphandlers.py instead. -->
   <column value="email" />
   <column value="fullname" />
+  <column value="nl_language" />
   <column value="salutation" />
   <column value="organization" />
 

--- a/Products/EasyNewsletter/profiles/default/jsregistry.xml
+++ b/Products/EasyNewsletter/profiles/default/jsregistry.xml
@@ -5,6 +5,6 @@
     cookable="False"
     inline="False"
     enabled="1"
-    expression="python: here.portal_type in ['EasyNewsletter', 'ENLIssue']" />
+    expression="context/@@load_enl_edithelper" />
 
 </object>

--- a/Products/EasyNewsletter/profiles/default/types/ENLIssue.xml
+++ b/Products/EasyNewsletter/profiles/default/types/ENLIssue.xml
@@ -45,6 +45,16 @@
     visible="True" i18n:attributes="title">
   <permission value="Modify portal content"/>
  </action>
+  <action title="Copy as draft" action_id="copy_as_draft" category="object_buttons"
+    condition_expr="python: portal.portal_workflow.getInfoFor(object, 'review_state') == 'master'" url_expr="string:${folder_url}/copy-as-draft"
+    visible="True" i18n:attributes="title">
+  <permission value="Modify portal content"/>
+ </action>
+   <action title="Copy as master" action_id="copy_as_master" category="object_buttons"
+    condition_expr="python: portal.portal_workflow.getInfoFor(object, 'review_state') in ['draft','sent']" url_expr="string:${folder_url}/copy-as-master"
+    visible="True" i18n:attributes="title">
+  <permission value="Modify portal content"/>
+ </action>
  <action title="Edit criteria" action_id="criteria" category="object_buttons"
     condition_expr="" url_expr="string:${folder_url}/criterion_edit_form"
     visible="True" i18n:attributes="title">

--- a/Products/EasyNewsletter/profiles/default/types/ENLIssue.xml
+++ b/Products/EasyNewsletter/profiles/default/types/ENLIssue.xml
@@ -48,12 +48,12 @@
   <action title="Copy as draft" action_id="copy_as_draft" category="object_buttons"
     condition_expr="python: portal.portal_workflow.getInfoFor(object, 'review_state') == 'master'" url_expr="string:${folder_url}/copy-as-draft"
     visible="True" i18n:attributes="title">
-  <permission value="Modify portal content"/>
+  <permission value="Copy or Move"/>
  </action>
    <action title="Copy as master" action_id="copy_as_master" category="object_buttons"
     condition_expr="python: portal.portal_workflow.getInfoFor(object, 'review_state') in ['draft','sent']" url_expr="string:${folder_url}/copy-as-master"
     visible="True" i18n:attributes="title">
-  <permission value="Modify portal content"/>
+  <permission value="Copy or Move"/>
  </action>
  <action title="Edit criteria" action_id="criteria" category="object_buttons"
     condition_expr="" url_expr="string:${folder_url}/criterion_edit_form"

--- a/Products/EasyNewsletter/profiles/default/types/EasyNewsletter.xml
+++ b/Products/EasyNewsletter/profiles/default/types/EasyNewsletter.xml
@@ -64,5 +64,5 @@
     condition_expr="" url_expr="string:${folder_url}/enl_templates_view"
     visible="True" i18n:attributes="title">
   <permission value="Modify portal content"/>
- </action> 
+ </action>
 </object>

--- a/Products/EasyNewsletter/profiles/default/workflows/enl_issue_workflow/definition.xml
+++ b/Products/EasyNewsletter/profiles/default/workflows/enl_issue_workflow/definition.xml
@@ -4,116 +4,194 @@
              description="- Essentially a workflow with no transitions, but has a Published state, so portlets and applications that expect that state will continue to work."
              state_variable="review_state"
              initial_state="draft">
- <permission>Access contents information</permission>
- <permission>Change portal events</permission>
- <permission>List folder contents</permission>
- <permission>Modify portal content</permission>
- <permission>View</permission>
- <state state_id="draft" title="Draft">
-  <exit-transition transition_id="send"/>
-  <permission-map name="Access contents information"
-                  acquired="False">
-   <permission-role>Manager</permission-role>
-   <permission-role>Owner</permission-role>
-  </permission-map>
-  <permission-map name="Change portal events"
-                  acquired="False">
-   <permission-role>Manager</permission-role>
-   <permission-role>Owner</permission-role>
-  </permission-map>
-  <permission-map name="List folder contents"
-                  acquired="False">
-   <permission-role>Manager</permission-role>
-   <permission-role>Owner</permission-role>
-  </permission-map>
-  <permission-map name="Modify portal content"
-                  acquired="False">
-   <permission-role>Manager</permission-role>
-   <permission-role>Owner</permission-role>
-  </permission-map>
-  <permission-map name="View" acquired="False">
-   <permission-role>Manager</permission-role>
-   <permission-role>Owner</permission-role>
-  </permission-map>
- </state>
- <state state_id="sent" title="Sent">
-  <exit-transition transition_id="make_draft"/>
-  <permission-map name="Modify portal content"
-                  acquired="False">
-  </permission-map>
- </state>
- <transition transition_id="make_draft" title="Make draft"
-             new_state="draft" trigger="USER"
-             before_script="" after_script="">
-  <action url="%(content_url)s/content_status_modify?workflow_action=make_draft"
-          category="workflow">Make draft</action>
-  <guard>
-   <guard-permission>Manage portal content</guard-permission>
-  </guard>
- </transition>
- <transition transition_id="send" title="Send"
-             new_state="sent" trigger="USER"
-             before_script="" after_script="">
-  <action url="%(content_url)s/content_status_modify?workflow_action=send"
-          category="workflow">Send</action>
-  <guard>
-   <guard-permission>Modify portal content</guard-permission>
-  </guard>
- </transition>
- <variable variable_id="action" for_catalog="False"
-           for_status="True" update_always="True">
-  <description>Previous transition</description>
-  <default>
-   
-   <expression>transition/getId|nothing</expression>
-  </default>
-  <guard>
-  </guard>
- </variable>
- <variable variable_id="actor" for_catalog="False"
-           for_status="True" update_always="True">
-  <description>The ID of the user who performed the previous transition
-</description>
-  <default>
-   
-   <expression>user/getUserName</expression>
-  </default>
-  <guard>
-  </guard>
- </variable>
- <variable variable_id="comments" for_catalog="False"
-           for_status="True" update_always="True">
-  <description>Comment about the last transition
-</description>
-  <default>
-   
-   <expression>python:state_change.kwargs.get('comment', '')</expression>
-  </default>
-  <guard>
-  </guard>
- </variable>
- <variable variable_id="review_history" for_catalog="False"
-           for_status="False" update_always="False">
-  <description>Provides access to workflow history
-</description>
-  <default>
-   
-   <expression>state_change/getHistory</expression>
-  </default>
-  <guard>
-   <guard-permission>Request review</guard-permission>
-   <guard-permission>Review portal content</guard-permission>
-  </guard>
- </variable>
- <variable variable_id="time" for_catalog="False"
-           for_status="True" update_always="True">
-  <description>When the previous transition was performed
-</description>
-  <default>
-   
-   <expression>state_change/getDateTime</expression>
-  </default>
-  <guard>
-  </guard>
- </variable>
+    <permission>Access contents information</permission>
+    <permission>Change portal events</permission>
+    <permission>List folder contents</permission>
+    <permission>Modify portal content</permission>
+    <permission>View</permission>
+    <state state_id="draft" title="Draft">
+        <exit-transition transition_id="send"/>
+        <exit-transition transition_id="make_master"/>
+        <permission-map name="Access contents information"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+        <permission-map name="Change portal events"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+        <permission-map name="List folder contents"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+        <permission-map name="Modify portal content"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+        <permission-map name="View" acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+    </state>
+    <state state_id="sent" title="Sent">
+        <permission-map name="Access contents information"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+        <permission-map name="Change portal events"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+        </permission-map>
+        <permission-map name="List folder contents"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+        <permission-map name="Modify portal content"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+        </permission-map>
+        <permission-map name="View" acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+    </state>
+    <state state_id="master" title="Master">
+        <permission-map name="Access contents information"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+        <permission-map name="Change portal events"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+        <permission-map name="List folder contents"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+        <permission-map name="Modify portal content"
+                        acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+        <permission-map name="View" acquired="False">
+            <permission-role>Manager</permission-role>
+            <permission-role>Owner</permission-role>
+            <permission-role>Editor</permission-role>
+        </permission-map>
+    </state>
+
+
+    <transition transition_id="make_draft" title="Make draft"
+                new_state="draft" trigger="USER"
+                before_script="" after_script="">
+        <action
+            url="%(content_url)s/content_status_modify?workflow_action=make_draft"
+            category="workflow">Make draft
+        </action>
+        <guard>
+            <guard-expression>python:here.REQUEST.get('enlwf_guard', False)</guard-expression>
+        </guard>
+    </transition>
+    <transition transition_id="send" title="Send"
+                new_state="sent" trigger="USER"
+                before_script="" after_script="">
+        <action url="%(content_url)s/content_status_modify?workflow_action=send"
+                category="workflow">Send
+        </action>
+        <guard>
+            <guard-expression>python:here.REQUEST.get('enlwf_guard', False)</guard-expression>
+        </guard>
+    </transition>
+
+    <transition transition_id="make_master" title="Make master"
+                new_state="master" trigger="USER"
+                before_script="" after_script="">
+        <action
+            url="%(content_url)s/content_status_modify?workflow_action=make_master"
+            category="workflow">Make master
+        </action>
+        <guard>
+            <guard-expression>python:here.REQUEST.get('enlwf_guard', False)</guard-expression>
+        </guard>
+    </transition>
+
+
+    <variable variable_id="action" for_catalog="False"
+              for_status="True" update_always="True">
+        <description>Previous transition</description>
+        <default>
+
+            <expression>transition/getId|nothing</expression>
+        </default>
+        <guard>
+        </guard>
+    </variable>
+    <variable variable_id="actor" for_catalog="False"
+              for_status="True" update_always="True">
+        <description>The ID of the user who performed the previous transition
+        </description>
+        <default>
+
+            <expression>user/getUserName</expression>
+        </default>
+        <guard>
+        </guard>
+    </variable>
+    <variable variable_id="comments" for_catalog="False"
+              for_status="True" update_always="True">
+        <description>Comment about the last transition
+        </description>
+        <default>
+
+            <expression>python:state_change.kwargs.get('comment', '')
+            </expression>
+        </default>
+        <guard>
+        </guard>
+    </variable>
+    <variable variable_id="review_history" for_catalog="False"
+              for_status="False" update_always="False">
+        <description>Provides access to workflow history
+        </description>
+        <default>
+
+            <expression>state_change/getHistory</expression>
+        </default>
+        <guard>
+            <guard-permission>Request review</guard-permission>
+            <guard-permission>Review portal content</guard-permission>
+        </guard>
+    </variable>
+    <variable variable_id="time" for_catalog="False"
+              for_status="True" update_always="True">
+        <description>When the previous transition was performed
+        </description>
+        <default>
+
+            <expression>state_change/getDateTime</expression>
+        </default>
+        <guard>
+        </guard>
+    </variable>
 </dc-workflow>

--- a/Products/EasyNewsletter/setuphandlers.py
+++ b/Products/EasyNewsletter/setuphandlers.py
@@ -34,6 +34,7 @@ def add_catalog_indexes(context, logger=None):
     indexes = catalog.indexes()
     # Specify the indexes you want, with ('index_name', 'index_type')
     wanted = (('fullname', 'FieldIndex'),
+              ('nl_language', 'FieldIndex'),
               ('email', 'FieldIndex'),
               ('organization', 'FieldIndex'),
               )

--- a/Products/EasyNewsletter/skins/EasyNewsletter/enl_masters_view.pt
+++ b/Products/EasyNewsletter/skins/EasyNewsletter/enl_masters_view.pt
@@ -1,0 +1,48 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      lang="en"
+      metal:use-macro="here/main_template/macros/master"
+      i18n:domain="EasyNewsletter">
+<body>
+
+<metal:main fill-slot="main">
+    <tal:main-macro metal:define-macro="main"
+           tal:define="kssClassesView context/@@kss_field_decorator_view;
+                       getKssClasses nocall:kssClassesView/getKssClassesInlineEditable;
+                       templateId template/getId;
+                       text here/getText;">
+
+        <div tal:replace="structure provider:plone.abovecontenttitle" />
+
+        <h1 class="documentFirstHeading">
+            <span tal:omit-tag=""
+                  i18n:translate="easynewsletter_masters_label">Masters</span>
+        </h1>
+        <a class="link-parent"
+           tal:attributes="href context/aq_parent/absolute_url"
+           i18n:translate="easynewsletter_backtonewsletter_label">
+           Back to newsletter
+        </a>
+
+        <div tal:define="newsletters context/get_master_issues">
+            <div tal:condition="not: newsletters"
+                 i18n:translate="easynewsletter_nondrafts_label">
+                  There are no masters.
+            </div>
+
+            <ul>
+                <li tal:repeat="newsletter newsletters">
+                    <a tal:define="toLocalizedTime nocall:context/@@plone/toLocalizedTime;
+                                   date python:toLocalizedTime(newsletter.modified, long_format=0)"
+                       tal:content="string:$date ${newsletter/Title}"
+                       tal:attributes="href newsletter/getURL">Newsletter's title and Date</a>
+                </li>
+            </ul>
+        </div>
+    </tal:main-macro>
+</metal:main>
+
+</body>
+</html>

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -12,6 +12,18 @@ parts +=
     zopepy
     scripts
 
+extensions =
+    mr.developer
+sources = sources
+auto-checkout = *
+#always-checkout = false
+always-checkout = force
+always-accept-server-certificate = true
+
+[sources]
+#plone.api had some nasty bugs - so until released master from github is needed to make this feature work in a a stable manner
+plone.api = git git@github.com:plone/plone.api.git
+
 [i18ndude]
 recipe = zc.recipe.egg
 eggs = i18ndude

--- a/docs/source/index.txt
+++ b/docs/source/index.txt
@@ -21,13 +21,13 @@ Features
     - Plonish (can use Plone's Collections to collect content)
 
     - Variable templates to generate newsletter content
-    
+
     - Subscribing / Unsubscribing and can use Plone Members/Groups as receivers (works also with Membrane)
-    
+
     - support for external subscriber sources (configured through a Zope utility)
-    
+
     - support for external delivery services (other than Plone MailHost)
-    
+
     - TTW customizeable output Template to generate nice HTML Newsletter
 
     - Support personalized mails
@@ -113,6 +113,19 @@ Step by step
 8. If your Newsletter/Mailing is finished, you can activate the send button by clicking on ``Enable send button``.
    Then you can click on ``Send newsletter`` to send the Newsletter to all subscribers or selected groups and users.
 
+Issue workflow information
+--------------------------
+
+There are now three workflow states for an issue, which are draft, sent and master.
+If an issue is created, it's initial state is draft.
+
+Only issues with state draft can be send.
+
+After an issue is sent, it's state is sent and it will appear in the newsletter archive.
+
+In addition a master can be made out of an issue with the state draft or sent using the actions menu.
+The master acts as a blueprint, which can be reedited and copied as a new draft.
+
 Images in HTML mails
 --------------------
 
@@ -160,7 +173,7 @@ IReceiversMemberFilter filters
 
 The IReceiversMemberFilter filters can be used to filter the list of Plone members which a user can select in newsletters and issues.
 
-:: 
+::
 
    class ReceiversMemberFilterNoPloneMember(object):
        """ filters all members out of newsletter receivers selection list,


### PR DESCRIPTION
...classing.

- Fixed jquery initialization in enl_edithelper.js and make it work again.
  It didn't hide the user selection fields.

- Status and error messsages show up for anon users (was broke).

- Implemented that subscribers and recipients have a language. This is also
  queable via index and the affecting page templates have been adjusted.

- Made a checkbox in the send issue form to exclude all external subscribers.

- Split up the send method for better hookability.

- Reworked the whole issue workflow. See README.

- Added info on several newsletter fields, that changing settings does not
  affect already existing issues for that newsletter.

- Fixed enl_edithelper.py work again.

- Added 2 new constants to the config.py for hookability and adjusted the
  affected files to look up those constants.

- Fixed A subscriber can now unsubscribe himself, if he is not logged in.

- Reworked the salutation mapping (prepared for multilingual newsletter)

@jensens @agitator please have a look