### PR TITLE
Do a transaction.commit() after changing the Issue workflow to 'sending' 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,16 @@ Changelog
 3.0a1 (unreleased)
 ------------------
 
+- Give a redirect with a status message back to the issue page after sending a
+  news letter issue directly (without asynchronous queueing), this was broken
+  after the zamqp support was added.
+  [fredvd]
+
+- Do a transaction.commit() after changing the Issue workflow to 'sending' so
+  we are certain another incoming request for sending the issue will see the
+  change and fail in direct send mode. (Fixes #83)
+  [fredvd]
+
 - Only add IDisableCSRFProtection to the unsubscribe view if the supported
   newer plone.protect is available. Don't force dependency on plone.protect
   3.X

--- a/Products/EasyNewsletter/tests/test_daily_issue.py
+++ b/Products/EasyNewsletter/tests/test_daily_issue.py
@@ -3,7 +3,7 @@ from Acquisition import aq_base
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.tests.utils import MockMailHost
 from Products.EasyNewsletter.interfaces import IENLIssue
-from Products.EasyNewsletter.testing import EASYNEWSLETTER_INTEGRATION_TESTING
+from Products.EasyNewsletter.testing import EASYNEWSLETTER_FUNCTIONAL_TESTING
 from Products.MailHost.interfaces import IMailHost
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import setRoles
@@ -16,7 +16,7 @@ import unittest
 class DailyIssueBaseTestCase(unittest.TestCase):
     """Test case sending a daily Newsletter issue"""
 
-    layer = EASYNEWSLETTER_INTEGRATION_TESTING
+    layer = EASYNEWSLETTER_FUNCTIONAL_TESTING
 
     def setUp(self):
         self.portal = self.layer["portal"]


### PR DESCRIPTION
so we are certain another incoming request for sending the issue will see the
change and fail in direct send mode. (Fixes #83)

Also give a redirect with a status message back to the issue page after sending an issue directly