### PR TITLE
Set effective date after sending an issue

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ Changelog
 - Show newsletter toolbar for reviewers.
   [agitator]
 
+- Set effective date after sending an issue.
+  [Gagaro]
+
 
 3.0.4 (2017-09-25)
 ------------------

--- a/Products/EasyNewsletter/content/ENLIssue.py
+++ b/Products/EasyNewsletter/content/ENLIssue.py
@@ -2,6 +2,7 @@
 # from plone.protect.auto import safeWrite
 from AccessControl import ClassSecurityInfo
 from archetypes.referencebrowserwidget.widget import ReferenceBrowserWidget
+from DateTime import DateTime
 from email.Header import Header
 from email.MIMEMultipart import MIMEMultipart
 from email.MIMEText import MIMEText
@@ -574,6 +575,8 @@ class ENLIssue(ATTopic, atapi.BaseContent):
             request['enlwf_guard'] = True
             api.content.transition(obj=self, transition='sending_completed')
             request['enlwf_guard'] = False
+            self.setEffectiveDate(DateTime())
+            self.reindexObject(idxs=['effective'])
 
     @security.protected('Modify portal content')
     def loadContent(self):


### PR DESCRIPTION
Sending an issue changes its state. Its effective date should be updated to be consistent with the other content types.