### PR TITLE
Add userid to member property dict for plone subscribers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.0.0a10 (unreleased)
 ---------------------
 
-- Nothing changed yet.
+- Add userid to member property dict for plone subscribers.
+  [thomasmassmann]
 
 
 5.0.0a9 (2019-12-14)

--- a/src/Products/EasyNewsletter/behaviors/plone_user_group_recipients.py
+++ b/src/Products/EasyNewsletter/behaviors/plone_user_group_recipients.py
@@ -160,6 +160,7 @@ class PloneUserGroupRecipients(object):
             language = member.getProperty("language") or self.context.language
             plone_subscribers.append(
                 {
+                    "userid": member.getUserId(),
                     "fullname": member.getProperty("fullname"),
                     "email": email,
                     "salutation": salutation.get(


### PR DESCRIPTION
Allows easier identification of members for future usage, e.g. with
IReceiversPostSendingFilter adapter. See #152.