### PR TITLE
Don't fail sending if there is a problem with at least one email

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 5.0.0b2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Don't fail sending process when one email fails.
+  [thomasmassmann]
 
 
 5.0.0b1 (2020-03-08)

--- a/src/Products/EasyNewsletter/views/newsletter_issue_send.py
+++ b/src/Products/EasyNewsletter/views/newsletter_issue_send.py
@@ -185,7 +185,7 @@ class NewsletterIssueSend(BrowserView):
                 receiver['status'] = send_status
 
         if not self.is_test:
-        # Add information to annotations
+            # Add information to annotations
             status_adapter = ISendStatus(self.context)
             if status_adapter:
                 status_adapter.add_records(receivers)

--- a/src/Products/EasyNewsletter/views/newsletter_issue_send.py
+++ b/src/Products/EasyNewsletter/views/newsletter_issue_send.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from datetime import datetime
 from DateTime import DateTime
 from plone import api

--- a/src/Products/EasyNewsletter/views/newsletter_issue_send.py
+++ b/src/Products/EasyNewsletter/views/newsletter_issue_send.py
@@ -182,7 +182,8 @@ class NewsletterIssueSend(BrowserView):
                 )
                 send_error_counter += 1
             finally:
-                receiver['status'] = send_status
+                if not self.is_test:
+                    receiver['status'] = send_status
 
         # Add information to annotations
         status_adapter = ISendStatus(self.context)

--- a/src/Products/EasyNewsletter/views/newsletter_issue_send.py
+++ b/src/Products/EasyNewsletter/views/newsletter_issue_send.py
@@ -132,48 +132,58 @@ class NewsletterIssueSend(BrowserView):
         # get issue data
         issue_data = issue_data_fetcher()
         for receiver in receivers:
-            personalized_html = issue_data_fetcher.personalize(
-                receiver, issue_data['body_html']
-            )
-            # get plain text version
-            personalized_plaintext = issue_data_fetcher.create_plaintext_message(
-                personalized_html
-            )
-
-            m = emails.Message(
-                html=personalized_html,
-                text=personalized_plaintext,
-                subject=issue_data['subject'],
-                mail_from=(sender_name, sender_email),
-                mail_to=(receiver['fullname'], receiver['email']),
-            )
-            m.transform(
-                images_inline=True,
-                base_url=self.context.absolute_url(),
-                cssutils_logging_level=logging.ERROR,
-            )
-            if 'HTTPLoaderError' in m.as_string():
-                log.exception(u"Transform message failed: {0}".format(m.as_string()))
             send_status = {
                 'successful': None,
                 'error': None,
                 'datetime': datetime.now(),
             }
             try:
-                self.mail_host.send(m.as_string(), immediate=True)
-                send_status['successful'] = True
-                log.info('Send newsletter to "%s"' % receiver['email'])
-                send_counter += 1
-            except Exception as e:  # noqa
+                personalized_html = issue_data_fetcher.personalize(
+                    receiver, issue_data['body_html']
+                )
+                # get plain text version
+                personalized_plaintext = issue_data_fetcher.create_plaintext_message(
+                    personalized_html
+                )
+
+                m = emails.Message(
+                    html=personalized_html,
+                    text=personalized_plaintext,
+                    subject=issue_data['subject'],
+                    mail_from=(sender_name, sender_email),
+                    mail_to=(receiver['fullname'], receiver['email']),
+                )
+                m.transform(
+                    images_inline=True,
+                    base_url=self.context.absolute_url(),
+                    cssutils_logging_level=logging.ERROR,
+                )
+                message_string = m.as_string()
+                if 'HTTPLoaderError' in message_string:
+                    log.exception(u"Transform message failed: {0}".format(message_string))
+                try:
+                    self.mail_host.send(message_string, immediate=True)
+                    send_status['successful'] = True
+                    log.info('Send newsletter to "%s"' % receiver['email'])
+                    send_counter += 1
+                except Exception as e:  # noqa
+                    send_status['successful'] = False
+                    send_status['error'] = e
+                    log.exception(
+                        'Sending newsletter to "%s" failed, with error "%s"!'
+                        % (receiver['email'], e)
+                    )
+                    send_error_counter += 1
+            except Exception as e:
                 send_status['successful'] = False
                 send_status['error'] = e
                 log.exception(
-                    'Sending newsletter to "%s" failed, with error "%s"!'
-                    % (receiver['email'], e)
+                    'Sending newsletter failed, with error "{0}"!'.format(e)
                 )
                 send_error_counter += 1
             finally:
                 receiver['status'] = send_status
+
         # Add information to annotations
         status_adapter = ISendStatus(self.context)
         if status_adapter:

--- a/src/Products/EasyNewsletter/views/newsletter_issue_send.py
+++ b/src/Products/EasyNewsletter/views/newsletter_issue_send.py
@@ -182,13 +182,13 @@ class NewsletterIssueSend(BrowserView):
                 )
                 send_error_counter += 1
             finally:
-                if not self.is_test:
-                    receiver['status'] = send_status
+                receiver['status'] = send_status
 
+        if not self.is_test:
         # Add information to annotations
-        status_adapter = ISendStatus(self.context)
-        if status_adapter:
-            status_adapter.add_records(receivers)
+            status_adapter = ISendStatus(self.context)
+            if status_adapter:
+                status_adapter.add_records(receivers)
         log.info(
             'Newsletter was sent to (%s) receivers. (%s) errors occurred!'
             % (send_counter, send_error_counter)

--- a/src/Products/EasyNewsletter/views/newsletter_issue_statistics.py
+++ b/src/Products/EasyNewsletter/views/newsletter_issue_statistics.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from datetime import datetime
 from plone import api
 from Products.EasyNewsletter import EasyNewsletterMessageFactory as _  # noqa
 from Products.EasyNewsletter.content.newsletter_issue import ISendStatus
@@ -29,8 +30,9 @@ class NewsletterIssueStatistics(BrowserView):
         status_adapter = ISendStatus(self.context)
         if not status_adapter:
             return
+        now = datetime.now()
         records = status_adapter.get_records()
-        records = sorted(records, key=lambda x: x.get('status', {}).get('datetime'))
+        records = sorted(records, key=lambda x: x.get('status', {}).get('datetime', now))
         self.failed = len(status_adapter.get_keys(successful=False))
         self.successful = len(status_adapter.get_keys(successful=True))
         self.total = len(records)


### PR DESCRIPTION
Currently when there is a problem with one email, the whole sending process is cancelled and no statistics are written. Instead of failing, add the exception to the statistics and go on...